### PR TITLE
Add missing styling to h5 tag

### DIFF
--- a/src/components/post-template/post-content.js
+++ b/src/components/post-template/post-content.js
@@ -24,6 +24,11 @@ const Wrapper = styled.div({
     marginTop: 60,
     marginBottom: 32
   },
+  h5: {
+    fontWeight: 'bold',
+    marginBottom: '1rem',
+    fontSize: '1.3rem'
+  },
   [['p', 'li']]: {
     ...largeTextStyles,
     marginBottom: 31


### PR DESCRIPTION
## Before
<img width="749" alt="Screen Shot 2020-05-07 at 10 16 56 AM" src="https://user-images.githubusercontent.com/6892666/81305112-f1afd200-904b-11ea-9eb6-30a698dd8b59.png">

## After
<img width="811" alt="Screen Shot 2020-05-07 at 10 16 48 AM" src="https://user-images.githubusercontent.com/6892666/81305081-e9579700-904b-11ea-8a23-0bebc698c4c6.png">