### PR TITLE
Migrate to gtag plugin from ga & add unified tracking id

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -63,9 +63,12 @@ module.exports = {
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',
     {
-      resolve: 'gatsby-plugin-google-analytics',
+      resolve: 'gatsby-plugin-google-gtag',
       options: {
-        trackingId: 'UA-74643563-11'
+        trackingIds: [
+          'UA-74643563-11',
+          'G-0BGG5V2W2K' // Unified GA4 tracking for tracking all web properties on the apollographql.com domain
+        ]
       }
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10525,13 +10525,23 @@
         "rss": "^1.2.2"
       }
     },
-    "gatsby-plugin-google-analytics": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.3.13.tgz",
-      "integrity": "sha512-K/6c9iByR8uDpFZuJrappjyMsVtWFwPyAkRlXFHhq2mmNtgZeRVKFf5XoGiOHCeMPEpBGE58LLana/F01LLteQ==",
+    "gatsby-plugin-google-gtag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-3.0.0.tgz",
+      "integrity": "sha512-6zTmPUkAHd4NOEK2HY72Xf4VDGjDxvTxUaX4pE8irFqywuOfcdrmKzhbmjPfGh7mwwe1Otj1hyonI8ugKqD1Fg==",
       "requires": {
-        "@babel/runtime": "^7.10.3",
-        "minimatch": "3.0.4"
+        "@babel/runtime": "^7.12.5",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
+          "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "gatsby-plugin-page-creator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10526,18 +10526,18 @@
       }
     },
     "gatsby-plugin-google-gtag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-3.0.0.tgz",
-      "integrity": "sha512-6zTmPUkAHd4NOEK2HY72Xf4VDGjDxvTxUaX4pE8irFqywuOfcdrmKzhbmjPfGh7mwwe1Otj1hyonI8ugKqD1Fg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-2.8.0.tgz",
+      "integrity": "sha512-ghvVjbcDszlt7/oaHvmx97WVceWbbMZQ7b6FSO4RY0FVUm/UkvrZldAxraioS1uEra+ndeEDyPM+MiftuDR8Aw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
-          "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gatsby-image": "^2.4.1",
     "gatsby-plugin-emotion": "^4.1.21",
     "gatsby-plugin-feed": "^2.5.1",
-    "gatsby-plugin-google-gtag": "^3.0.0",
+    "gatsby-plugin-google-gtag": "^2.8.0",
     "gatsby-plugin-react-helmet": "^3.1.21",
     "gatsby-plugin-sharp": "^2.4.5",
     "gatsby-plugin-svgr": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gatsby-image": "^2.4.1",
     "gatsby-plugin-emotion": "^4.1.21",
     "gatsby-plugin-feed": "^2.5.1",
-    "gatsby-plugin-google-analytics": "^2.1.35",
+    "gatsby-plugin-google-gtag": "^3.0.0",
     "gatsby-plugin-react-helmet": "^3.1.21",
     "gatsby-plugin-sharp": "^2.4.5",
     "gatsby-plugin-svgr": "^2.0.2",

--- a/src/components/post-template/post-action.js
+++ b/src/components/post-template/post-action.js
@@ -7,7 +7,7 @@ import {colors} from '@apollo/space-kit/colors';
 import {decode} from 'he';
 import {size} from 'polished';
 import {stripHtmlTags} from '../../utils';
-import {trackCustomEvent} from 'gatsby-plugin-google-analytics';
+import {trackCustomEvent} from '../../utils';
 
 const Wrapper = styled.div({
   display: 'flex',

--- a/src/components/post-template/post-action.js
+++ b/src/components/post-template/post-action.js
@@ -6,8 +6,7 @@ import {IconClose} from '@apollo/space-kit/icons/IconClose';
 import {colors} from '@apollo/space-kit/colors';
 import {decode} from 'he';
 import {size} from 'polished';
-import {stripHtmlTags} from '../../utils';
-import {trackCustomEvent} from '../../utils';
+import {stripHtmlTags, trackCustomEvent} from '../../utils';
 
 const Wrapper = styled.div({
   display: 'flex',

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,14 @@
 const {decode} = require('he');
 
+function trackCustomEvent({category, action, label, value}) {
+  if (window.gtag) {
+    window.gtag('event', action, {
+      category,
+      label,
+      value
+    });
+  }
+}
+
+exports.trackCustomEvent = trackCustomEvent;
 exports.stripHtmlTags = (string) => decode(string.replace(/(<([^>]+)>)/g, ''));


### PR DESCRIPTION
This PR migrates from [`gatsby-plugin-google-analytics`](https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics/) to [`gatsby-plugin-google-gtag`](https://www.gatsbyjs.com/plugins/gatsby-plugin-google-gtag/) and adds a new tracking ID that will be used to track users across all `.apollographql.com` web properties as one session.

[Gtag is also Google's latest recommended way of using Analytics.](https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs)