### PR TITLE
Downgrade Google Tag Manager plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10545,17 +10545,17 @@
       }
     },
     "gatsby-plugin-google-tagmanager": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-3.0.0.tgz",
-      "integrity": "sha512-qhbmiEPUeexSgsWfHL1hs853W+xkC8zM6NzHlsAnnmPak0y76yFKsNppGz/UbrbD5SBzZ5i6xETVL84Ytqlm+A==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.11.0.tgz",
+      "integrity": "sha512-TElfBrcitk3bYphBpfFv7rI+tYQ/SwKhQMNKj3J31yoVUh/GUu2/FnRwEpvNbfGkTql87DffxR/83mN4vUCWOA==",
       "requires": {
         "@babel/runtime": "^7.12.5"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gatsby-plugin-emotion": "^4.1.21",
     "gatsby-plugin-feed": "^2.5.1",
     "gatsby-plugin-google-gtag": "^2.8.0",
-    "gatsby-plugin-google-tagmanager": "^3.0.0",
+    "gatsby-plugin-google-tagmanager": "^2.11.0",
     "gatsby-plugin-netlify": "^2.11.1",
     "gatsby-plugin-react-helmet": "^3.1.21",
     "gatsby-plugin-sharp": "^2.4.5",


### PR DESCRIPTION
This PR downgrades the Google Tag Manager plugin to v2.