### PR TITLE
Remove root redirect and build deploy previews at /

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,5 @@
   NODE_VERSION = "12"
   MAILCHIMP_LIST_ID = "c59c3cf70b"
   WORDPRESS_URL = "https://wp.apollographql.com/graphql"
+[context.deploy-preview]
+  command = "gatsby build"

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,5 +1,3 @@
-/ /blog
-
 # old posts
 /blog/apollo-client-now-with-react-hooks-676d116eeae2 /blog/announcement/frontend/apollo-client-now-with-react-hooks
 /blog/improve-graphql-performance-with-automatic-persisted-queries-c31d27b8e6ea /blog/announcement/platform/improve-graphql-performance-with-automatic-persisted-queries


### PR DESCRIPTION
This branch removes the root-level redirect and forces deploy previews to be deployed at the root to account for this change.