### PR TITLE
Updating tag manager plugin to use an env var if it exists

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -149,7 +149,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
-        id: 'GTM-M964NS9'
+        id: process.env.GTM_CONTAINER_ID || 'GTM-M964NS9'
       }
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -149,7 +149,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
-        id: process.env.GTM_CONTAINER_ID || 'GTM-M964NS9'
+        id: process.env.GTM_CONTAINER_ID
       }
     },
     {


### PR DESCRIPTION
This PR adds the ability to use an env var for the google tag manager container if it exists.