### PR TITLE
Revert "Updating tag manager plugin to use an env var if it exists"

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -149,7 +149,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
-        id: process.env.GTM_CONTAINER_ID
+        id: 'GTM-M964NS9'
       }
     },
     {


### PR DESCRIPTION
Reverts apollographql/blog#33