### PR TITLE
Remove noreferrer/noopener on odyssey cta link

### DIFF
--- a/src/components/odyssey.js
+++ b/src/components/odyssey.js
@@ -24,7 +24,6 @@ export default function Odyssey() {
         as={<a />}
         href="https://odyssey.apollographql.com/"
         target="_blank"
-        rel="noopener noreferrer"
         onClick={() => {
           trackCustomEvent({
             category: 'Blog sidebar',


### PR DESCRIPTION
This PR removes `rel=noopener noreferrer` from the Odyssey CTA link as it seems to be effecting Googles ability to follow the link or properly attribute the referrer on the Odyssey side.