### PR TITLE
Adding paging to category meta descriptions 

### DIFF
--- a/src/components/category-template.js
+++ b/src/components/category-template.js
@@ -19,6 +19,7 @@ import {
   categoryStyles,
   selectedCategoryStyles
 } from './ui';
+import {generateMetaTitle} from '../utils';
 import {graphql} from 'gatsby';
 
 const StyledCategories = styled(CategoriesBase)({
@@ -53,6 +54,11 @@ export default function CategoryTemplate(props) {
     ? `${wpParent.node.name} > ${name}`
     : name;
   const metaTitle = `${categorySlug} | ${pageInfo.currentPage}`;
+  const metaDescIntro =
+    pageInfo.currentPage === 1
+      ? `Read the latest ${categorySlug} posts`
+      : `${categorySlug} posts page ${pageInfo.currentPage} of ${pageInfo.pageCount}`;
+  const metaDescription = `${metaDescIntro} | ${props.data.wp.generalSettings.description}`;
 
   const topicSelector = topics.length > 0 && (
     <StyledCategories>
@@ -84,10 +90,7 @@ export default function CategoryTemplate(props) {
 
   return (
     <Layout>
-      <Metas
-        title={metaTitle}
-        description={`Read the latest ${categorySlug} posts | ${props.data.wp.generalSettings.description}`}
-      />
+      <Metas title={metaTitle} description={metaDescription} />
       {hasMorePosts && isFirstPage && latestPosts}
       <InnerWrapper>
         <Main>


### PR DESCRIPTION
This PR adds paging to the category template meta descriptions in order to clean up some additional duplicate meta errors in SEMRush.