### PR TITLE
Changed Heading to `display: block`

### DIFF
--- a/src/components/post-template/post-content.js
+++ b/src/components/post-template/post-content.js
@@ -41,7 +41,7 @@ const ANCHOR_OFFSET = 8;
 const Wrapper = styled.div({
   color: HEADING_COLOR,
   [HEADINGS]: {
-    display: 'flex',
+    display: 'block',
     '.aal_anchor': {
       visibility: 'hidden',
       display: 'flex',


### PR DESCRIPTION
Headings had an issue with code blocks because of the flex styling. It led to the text being in one column, and the codeblock in the next. This changes makes headings block instead.