### PR TITLE
Adding new ga4 tag

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,7 +72,8 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-google-gtag',
       options: {
-        trackingIds: ['UA-74643563-11', 'G-0BGG5V2W2K']
+        // todo: remove ua property in the nearish future
+        trackingIds: ['UA-74643563-11', 'G-0BGG5V2W2K', 'G-EE5WGLBMK6']
       }
     },
     {


### PR DESCRIPTION
This PR adds the newly created GA4 tag to support our GA4 migration effort.

https://apollographql.quip.com/GqFsAHXaowyM/UA-to-GA4-Migration