### PR TITLE
update plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gatsby": "^3.11.1",
     "gatsby-plugin-algolia": "^0.22.0",
     "gatsby-plugin-apollo": "^4.0.3",
-    "gatsby-plugin-apollo-onetrust": "github:apollographql/gatsby-plugin-apollo-onetrust",
+    "gatsby-plugin-apollo-onetrust": "github:apollographql/gatsby-plugin-apollo-onetrust#main",
     "gatsby-plugin-emotion": "^4.5.0",
     "gatsby-plugin-env-variables": "^2.1.0",
     "gatsby-plugin-feed": "^3.11.0",


### PR DESCRIPTION
This PR updates the version of gatsby-plugin-apollo-onetrust in order to have the auto blocking feature disabled for OneTrust so we can start recapturing GA data on non-consenting users.

We're able to do this because of the way uses "cookieless tracking".